### PR TITLE
Added HP and Damage scripts, demo in SampleScene

### DIFF
--- a/Assets/Prefabs/Player/3rdPersonPlayerCharacter.prefab
+++ b/Assets/Prefabs/Player/3rdPersonPlayerCharacter.prefab
@@ -165,7 +165,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3133493523865076750}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.00011261917, y: 0.9986045, z: -0.0021311864, w: 0.052769672}
+  m_LocalRotation: {x: 0.00011261927, y: 0.9986045, z: -0.0021311883, w: 0.052769672}
   m_LocalPosition: {x: -0.000009536743, y: 0, z: 0.000014305115}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -371,7 +371,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3740999712883411109}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.005985191, y: 0.9921628, z: -0.113262795, w: 0.052429255}
+  m_LocalRotation: {x: 0.005985195, y: 0.9921628, z: -0.113262795, w: 0.052429292}
   m_LocalPosition: {x: -0.000009536743, y: 0, z: 0.000014305115}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -565,7 +565,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7416013303308968637}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.0059851906, y: 0.99216276, z: -0.11326282, w: 0.052429236}
+  m_LocalRotation: {x: 0.005985198, y: 0.99216276, z: -0.11326282, w: 0.052429304}
   m_LocalPosition: {x: -14.846706, y: 9.145283, z: 11.2029705}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -975,11 +975,64 @@ PrefabInstance:
       propertyPath: m_Name
       value: Player
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 404224793542679031, guid: 16a57b20707ff46b0b48670c00a3bf7b, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 8471999139312667361, guid: 16a57b20707ff46b0b48670c00a3bf7b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 666137780769690654}
+    - targetCorrespondingSourceObject: {fileID: 8471999139312667361, guid: 16a57b20707ff46b0b48670c00a3bf7b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7022734507237587737}
   m_SourcePrefab: {fileID: 100100000, guid: 16a57b20707ff46b0b48670c00a3bf7b, type: 3}
+--- !u!1 &42793722508240259 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8471999139312667361, guid: 16a57b20707ff46b0b48670c00a3bf7b, type: 3}
+  m_PrefabInstance: {fileID: 8433728063021117282}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &666137780769690654
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 42793722508240259}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6161ad014f52d44b9b036b46a8bde713, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxHP: 3
+  currentHP: 3
+--- !u!54 &7022734507237587737
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 42793722508240259}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!4 &4096133072644545289 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5607823412398978155, guid: 16a57b20707ff46b0b48670c00a3bf7b, type: 3}

--- a/Assets/Prefabs/Player/TopDownPlayerCharacter.prefab
+++ b/Assets/Prefabs/Player/TopDownPlayerCharacter.prefab
@@ -369,11 +369,64 @@ PrefabInstance:
       propertyPath: m_Name
       value: Player
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 404224793542679031, guid: 16a57b20707ff46b0b48670c00a3bf7b, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 8471999139312667361, guid: 16a57b20707ff46b0b48670c00a3bf7b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 181081467229233442}
+    - targetCorrespondingSourceObject: {fileID: 8471999139312667361, guid: 16a57b20707ff46b0b48670c00a3bf7b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 694060742438748211}
   m_SourcePrefab: {fileID: 100100000, guid: 16a57b20707ff46b0b48670c00a3bf7b, type: 3}
+--- !u!1 &1664713277887408256 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8471999139312667361, guid: 16a57b20707ff46b0b48670c00a3bf7b, type: 3}
+  m_PrefabInstance: {fileID: 7100111400315347553}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &181081467229233442
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1664713277887408256}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6161ad014f52d44b9b036b46a8bde713, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxHP: 3
+  currentHP: 3
+--- !u!54 &694060742438748211
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1664713277887408256}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!4 &3412132154477876746 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5607823412398978155, guid: 16a57b20707ff46b0b48670c00a3bf7b, type: 3}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1293,14 +1293,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: -6448071449043873157, guid: e1d9101af5d96d94ca99efe2de0bac21, type: 3}
+    m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 100000, guid: e1d9101af5d96d94ca99efe2de0bac21, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2120656166}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e1d9101af5d96d94ca99efe2de0bac21, type: 3}
 --- !u!1001 &317706440
 PrefabInstance:
@@ -3087,6 +3083,71 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4f32dfddb033d3e40b5841bc53cc1689, type: 3}
+--- !u!1001 &631938554
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 55.21
+      objectReference: {fileID: 0}
+    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 64.51683
+      objectReference: {fileID: 0}
+    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6308069656668087040, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 13.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 6854439894564937020, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 13.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 9142751346430608809, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
+      propertyPath: m_Name
+      value: TopDownPlayerCharacter
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
 --- !u!1001 &637219830
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3565,6 +3626,12 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 100000, guid: 6fa2aa0a1d56aba4a8884471618de9e4, type: 3}
       insertIndex: -1
       addedObject: {fileID: 2083141607}
+    - targetCorrespondingSourceObject: {fileID: 100000, guid: 6fa2aa0a1d56aba4a8884471618de9e4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2083141612}
+    - targetCorrespondingSourceObject: {fileID: 100000, guid: 6fa2aa0a1d56aba4a8884471618de9e4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2083141611}
   m_SourcePrefab: {fileID: 100100000, guid: 6fa2aa0a1d56aba4a8884471618de9e4, type: 3}
 --- !u!1001 &733816679
 PrefabInstance:
@@ -7556,71 +7623,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f75f232634166cc459a69e7fd7a30880, type: 3}
---- !u!1001 &1574075184
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 4.4878387
-      objectReference: {fileID: 0}
-    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 4.9305115
-      objectReference: {fileID: 0}
-    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 2860619221382258887, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6308069656668087040, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 13.13
-      objectReference: {fileID: 0}
-    - target: {fileID: 6854439894564937020, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 13.13
-      objectReference: {fileID: 0}
-    - target: {fileID: 9142751346430608809, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
-      propertyPath: m_Name
-      value: TopDownPlayerCharacter
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 738974e905c6d4d78906e7d99655b037, type: 3}
 --- !u!4 &1583879740 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 400000, guid: d34e8533c8de8ec45869f9144584d929, type: 3}
@@ -9707,7 +9709,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2083141602}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: edc7ddf74d9682d4c9a0b524152a2d6a, type: 3}
   m_Name: 
@@ -9739,6 +9741,40 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!114 &2083141611
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2083141602}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 626c10346ec3f4be6b3b68febef28456, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damage: 1
+--- !u!65 &2083141612
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2083141602}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 3.6267593, y: 3.0141315, z: 1.0707195}
+  m_Center: {x: -0.004736781, y: 1.8421111, z: 4.227091}
 --- !u!4 &2107557315 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 400000, guid: 4f32dfddb033d3e40b5841bc53cc1689, type: 3}
@@ -9754,33 +9790,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 400000, guid: 47ea3e3caeb3c2845bbd9339bdc7a282, type: 3}
   m_PrefabInstance: {fileID: 693016487}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &2120656163 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 100000, guid: e1d9101af5d96d94ca99efe2de0bac21, type: 3}
-  m_PrefabInstance: {fileID: 295338755}
-  m_PrefabAsset: {fileID: 0}
---- !u!64 &2120656166
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2120656163}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 5
-  m_Convex: 0
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 4300000, guid: a120bc9095fe23d458dc299a94dc00a8, type: 3}
 --- !u!1001 &2140485346
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9849,4 +9858,4 @@ SceneRoots:
   m_Roots:
   - {fileID: 705507995}
   - {fileID: 356167992}
-  - {fileID: 1574075184}
+  - {fileID: 631938554}

--- a/Assets/Scripts/Attack.cs
+++ b/Assets/Scripts/Attack.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Attach this to an Attacking object and make a collider with isTrigger enabled on the attacker, large enough for the player to enter into.
+/// </summary>
+public class Attack : MonoBehaviour
+{
+    public int damage = 1;
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/Attack.cs.meta
+++ b/Assets/Scripts/Attack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 626c10346ec3f4be6b3b68febef28456
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/HitPoints.cs
+++ b/Assets/Scripts/HitPoints.cs
@@ -1,0 +1,30 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+/// <summary>
+/// Two things that will contact must both have a collider, the attack should be a collider set to isTrigger, and one must have a rigidbody. The player has a rigid body and characterController (that counts a trigger) for this purpose. When you attach the attack, make sure to add an isTrigger collider
+/// </summary>
+public class HitPoints : MonoBehaviour
+{
+    public int maxHP = 3;
+    public int currentHP = 3;
+
+    private void OnTriggerEnter(Collider collision){
+        Attack other = collision.gameObject.GetComponent<Attack>();
+        if(other != null){
+            currentHP -= other.damage;
+        }
+    }
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/HitPoints.cs.meta
+++ b/Assets/Scripts/HitPoints.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6161ad014f52d44b9b036b46a8bde713
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
closes #30 

I have added both a HP script and an Attack script in this PR. 
The attack script must be connected to an aggressive object with a collider set to isTrigger that the player can overlap with as in this image
![Screenshot 2024-04-16 at 9 00 34 PM](https://github.com/KTFBP/SqPreview/assets/94402266/05a81916-38c1-4b42-ba45-a8db81fcb3ae)

If there are multiple triggers, it might cause issues where the script triggers multiple times and would need refactoring to fix that behavior.

On entering the trigger, the damage from the attack is removed from the squirrels HP
![Screenshot 2024-04-16 at 9 00 46 PM](https://github.com/KTFBP/SqPreview/assets/94402266/e9f46659-fe51-4485-ac15-22e85d4ecab3)

Both character prefabs have been modified to make this work.